### PR TITLE
fix: UTF-8 safe string truncation

### DIFF
--- a/internal/cli/compact/compact_test.go
+++ b/internal/cli/compact/compact_test.go
@@ -26,6 +26,7 @@ func TestTruncateString(t *testing.T) {
 		{"exactly10!", 10, "exactly10!"},
 		{"this is a longer string", 10, "this is..."},
 		{"", 10, ""},
+		{"hello — world of things", 10, "hello —..."},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/compact/sanitize.go
+++ b/internal/cli/compact/sanitize.go
@@ -8,6 +8,7 @@ package compact
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/ActiveMemory/ctx/internal/config"
 )
@@ -73,8 +74,9 @@ func removeEmptySections(content string) (string, int) {
 // Returns:
 //   - string: Original string if within limit, otherwise truncated with "..."
 func truncateString(s string, maxLen int) string {
-	if len(s) <= maxLen {
+	if utf8.RuneCountInString(s) <= maxLen {
 		return s
 	}
-	return s[:maxLen-3] + config.Ellipsis
+	runes := []rune(s)
+	return string(runes[:maxLen-3]) + config.Ellipsis
 }

--- a/internal/cli/journal/generate.go
+++ b/internal/cli/journal/generate.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/ActiveMemory/ctx/internal/config"
 )
@@ -211,8 +212,9 @@ func generateZensicalToml(
 	)
 	for _, e := range recent {
 		title := e.Title
-		if len(title) > config.JournalMaxNavTitleLen {
-			title = title[:config.JournalMaxNavTitleLen] + config.Ellipsis
+		if utf8.RuneCountInString(title) > config.JournalMaxNavTitleLen {
+			runes := []rune(title)
+			title = string(runes[:config.JournalMaxNavTitleLen]) + config.Ellipsis
 		}
 		title = strings.ReplaceAll(title, `"`, `\"`)
 		sb.WriteString(fmt.Sprintf(

--- a/internal/cli/status/preview.go
+++ b/internal/cli/status/preview.go
@@ -8,6 +8,7 @@ package status
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/ActiveMemory/ctx/internal/config"
 )
@@ -52,9 +53,10 @@ func contentPreview(content string, n int) []string {
 		}
 
 		// Truncate long lines
-		if len(trimmed) > config.MaxPreviewLen {
-			truncateAt := config.MaxPreviewLen - len(config.Ellipsis)
-			trimmed = trimmed[:truncateAt] + config.Ellipsis
+		if utf8.RuneCountInString(trimmed) > config.MaxPreviewLen {
+			runes := []rune(trimmed)
+			truncateAt := config.MaxPreviewLen - utf8.RuneCountInString(config.Ellipsis)
+			trimmed = string(runes[:truncateAt]) + config.Ellipsis
 		}
 
 		preview = append(preview, trimmed)


### PR DESCRIPTION
## Summary

- Switch all string truncation from byte-length (`len(s)`) to rune-count (`utf8.RuneCountInString`) and rune-slicing (`[]rune(s)[:n]`)
- Fixes `UnicodeDecodeError` when multi-byte chars (e.g. em-dash `—`) get split mid-sequence during TOML generation
- Adds UTF-8 test case to `TestTruncateString`

Fixes #11

## Test plan

- [x] `go test ./internal/cli/compact/` — truncateString with multi-byte chars
- [x] `go test ./internal/cli/journal/` — nav title truncation
- [x] `go test ./internal/cli/status/` — preview line truncation
- [x] `ctx journal site --build` — full site build with 311 entries, no errors
