### PR TITLE
fix: add required flags to decision example in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ ctx agent --budget 4000
 
 # Add tasks, decisions, learnings
 ctx add task "Implement user authentication"
-ctx add decision "Use PostgreSQL for primary database"
+ctx add decision "Use PostgreSQL for primary database" \
+  --context "Need a reliable database for production workloads" \
+  --rationale "PostgreSQL offers ACID compliance, JSON support, and team familiarity" \
+  --consequences "Team needs PostgreSQL training; must set up replication"
 ctx add learning "Mock functions must be hoisted in Jest"
 ```
 


### PR DESCRIPTION
## Summary
Updated the `ctx add decision` example in the Quick Start section of [README.md](cci:7://file:///c:/Users/user/Desktop/securepay/ctx/README.md:0:0-0:0). The previous example caused an error because it was missing the mandatory flags (`--context`, `--rationale`, `--consequences`) required by the [ctx](cci:7://file:///c:/Users/user/Desktop/securepay/ctx/ctx:0:0-0:0) CLI.

## Changes
- Updated the `ctx add decision` command in [README.md](cci:7://file:///c:/Users/user/Desktop/securepay/ctx/README.md:0:0-0:0) to include valid example values for all required flags.

## Type of Change
- [x] Documentation Update
- [ ] Bug Fix
- [ ] New Feature
- [ ] Refactor

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] My code follows the code style of this project
- [x] I have signed off my commits with `git commit -s`